### PR TITLE
python-client-version

### DIFF
--- a/python/simple-producer-consumer/create-project.sh
+++ b/python/simple-producer-consumer/create-project.sh
@@ -2,4 +2,4 @@ mkdir SimpleProducerConsumer && cd SimpleProducerConsumer
 
 touch index.py
 
-pip install pulsar-client==2.10.2
+pip install pulsar-client==2.10


### PR DESCRIPTION
"pip install pulsar-client==2.10.2"
throws errors that a correct version can't be found.
I tested "pip install pulsar-client==2.10" with the example and it works as it should.